### PR TITLE
Fix sbt dependency version error and deprecation warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,10 @@
 import sbt.Keys._
 
 
-
 name := "bwhc-rest-api-gateway"
-organization in ThisBuild := "de.bwhc"
-scalaVersion in ThisBuild := "2.13.8"
-version in ThisBuild := "1.1-SNAPSHOT"
+ThisBuild / organization := "de.bwhc"
+ThisBuild / scalaVersion := "2.13.8"
+ThisBuild / version := "1.1-SNAPSHOT"
 
 
 scalacOptions ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,3 +2,5 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.15")
 
 //addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+
+ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always


### PR DESCRIPTION
Additional setting 'libraryDependencySchemes' prevents sbt from ending up in error using dependencyOverrides for 'scala-xml' using Scala 2.13.

This fix also uses new '/' syntax for project settings.